### PR TITLE
fix i19n translate issues

### DIFF
--- a/i18n/en.json
+++ b/i18n/en.json
@@ -70,6 +70,14 @@
   "App.profile.managingJobs": "List of all jobs you are managing.",
   "App.profile.evaluatingJobs": "List of all jobs you are listed as the Evaluator.",
   "App.profile.sponsoringJobs": "List of all jobs you've sponsored.",
+  "App.profile.incompleteJobsTitle":"Incomplete Jobs",
+  "App.profile.completedJobsTitle":"Completed Jobs",
+  "App.profile.canceledJobsTitle":"Canceled Jobs",
+  "App.profile.managingJobsTitle":"Jobs You're Managing",
+  "App.profile.evaluatingJobsTitle":"Jobs You're Evaluating",
+  "App.profile.sponsoringJobsTitle":"Jobs You've Sponsored",
+  "App.profile.countryCodeTitle":"Country Code",
+  "App.profile.numberTitle":"Number",
   "App.job.evaluation": "Evaluation",
   "App.job.cityOfWork": "City Where Work is to be Performed",
   "App.job.evaluationDescription": "After a job is claimed an evaluator must be assigned. An evaluator confirms the completion of work. If assigned as an evaluator the below area will show additional information.",
@@ -148,6 +156,10 @@
   "App.createJob.salaryPayoutDisclaimer": "Remember: (1) The salary you list above will be deducted and paid to the worker evenly based on the total months you have typed above. (2) We collect 2% of the total salary amount. Based on the salary you have entered above the worker in total will receive approximately: ",
   "App.createJob.pageDescription": "Use the form below to create a 6-month or 12-month job.",
   "App.createJob.requirementInstructions": "Please add your requirements in order for the job to be considered as complete. Add one requirement, then click Add Requirement, to add additional requirements.",
+  "App.createJob.JobDescriptionInForm": "Job Description",
+  "App.createJob.requirementInForm": "Requirement for Job to be Complete",
+  "App.createJob.nrMonthsInForm": "Number of Months of Employment",
+  "App.createJob.totalFoundingInForm": "Total Funding (Salary) for Job in USD",
   "App.footer.userGuide": "User Guide",
   "App.footer.getStartedGuide": "Get Started",
   "App.footer.codeOfConduct": "Code of Conduct",
@@ -197,5 +209,23 @@
   "components.register.terms": "I accept the <a href=\"/\">Terms and Conditions</a>",
   "components.register.title": "Register",
   "components.truncate.showLess": "Show less",
-  "components.truncate.showMore": "Show more"
+  "components.truncate.showMore": "Show more",
+  "domainOptions": [
+    {"label": "Choose a Domain", "value": null},
+    {"label": "Community", "value": "community"},
+    {"label": "Education", "value": "education"},
+    {"label": "Environment", "value": "environment"}
+  ],
+  "skillOptions": [
+    {"label": "Choose Top Desired Skill", "value": null},
+    {"label": "Administrative", "value": "administrative"},
+    {"label": "Engineering", "value": "engineering"},
+    {"label": "Labor", "value": "labor"},
+    {"label": "Teaching", "value": "teaching"}
+  ],
+  "countryOptions": [
+    {"label": "Choose a Country", "value": null},
+    {"label": "Haiti", "value": "haiti"},
+    {"label": "USA", "value": "us"}
+  ]
 }

--- a/i18n/ht.json
+++ b/i18n/ht.json
@@ -70,6 +70,14 @@
   "App.profile.managingJobs": "Lis tout djòb w ap jere.",
   "App.profile.evaluatingJobs": "Lis tout ou te mete tankou yon evalyatè.",
   "App.profile.sponsoringJobs": "Lis tout travay ou te patwone.",
+  "App.profile.incompleteJobsTitle":"Incomplete Jobs Kreyol",
+  "App.profile.completedJobsTitle":"Completed Jobs Kreyol",
+  "App.profile.canceledJobsTitle":"Canceled Jobs Kreyol",
+  "App.profile.managingJobsTitle":"Jobs You're Managing Kreyol",
+  "App.profile.evaluatingJobsTitle":"Jobs You're Evaluating Kreyol",
+  "App.profile.sponsoringJobsTitle":"Jobs You've Sponsored kreyol",
+  "App.profile.countryCodeTitle":"Country Code Kreyol",
+  "App.profile.numberTitle":"Number Kreyol",
   "App.job.evaluation": "Evaliyason",
   "App.job.cityOfWork": "Vil kote travay la dwe fèt",
   "App.job.claim": "Reklamasyon",
@@ -148,6 +156,10 @@
   "App.createJob.salaryPayoutDisclaimer": "Sonje: (1) Salè ou lis anwo a ap fèt dedui ak peye travayè a respire ki baze sou mwa yo total ou te tape pi wo a. (2) Nou kolekte 2% kantite lajan total salè. Ki baze sou salè ou te antre anlè travayè a nan total pral resevwa apeprè: ",
   "App.createJob.pageDescription": "Itilize fòm ki anba a pou kreye yon travay 6 mwa oswa 12 mwa.",
   "App.createJob.requirementInstructions": "Tanpri ajoute kondisyon ou yo nan lòd pou travay la yo dwe konsidere kòm konplè. Add yon egzijans, epi klike sou Add Requirement, pou ajoute lòt kondisyon.",
+  "App.createJob.JobDescriptionInForm": "Job Description Kreyol",
+  "App.createJob.requirementInForm": "Requirement for Job Kreyol",
+  "App.createJob.nrMonthsInForm": "Number of Months of Employment Kreyol",
+  "App.createJob.totalFoundingInForm": "Total Funding (Salary) for Job in USD Kreyol",
   "App.footer.userGuide": "Gid Itilizatè",
   "App.footer.getStartedGuide": "Ann kòmanse",
   "App.footer.codeOfConduct": "Kòd Konduit",
@@ -198,5 +210,23 @@
   "components.register.terms": "I accept the <a href=\"/\">Terms and Conditions</a>",
   "components.register.title": "Enskri",
   "components.truncate.showLess": "Montre mwens",
-  "components.truncate.showMore": "Montre plis"
+  "components.truncate.showMore": "Montre plis",
+  "domainOptions": [
+    {"label": "Choose a Domain Kreyol", "value": null},
+    {"label": "Community Kreyol", "value": "community"},
+    {"label": "Education Kreyol", "value": "education"},
+    {"label": "Environment Kreyol", "value": "environment"}
+  ],
+  "skillOptions": [
+    {"label": "Choose Top Desired Skill Kreyol", "value": null},
+    {"label": "Administrative Kreyol", "value": "administrative"},
+    {"label": "Engineering Kreyol", "value": "engineering"},
+    {"label": "Labor Kreyol", "value": "labor"},
+    {"label": "Teaching Kreyol", "value": "teaching"}
+  ],
+  "countryOptions": [
+    {"label": "Choose a Country Kreyol", "value": null},
+    {"label": "Haiti Kreyol", "value": "haiti"},
+    {"label": "USA Kreyol", "value": "us"}
+  ]
 }

--- a/src/components/createJob.vue
+++ b/src/components/createJob.vue
@@ -29,7 +29,7 @@
                   <vue-input
                     name="task"
                     id="task"
-                    placeholder="Job Title"
+                    :placeholder="$t('App.createJob.JobTitleInForm')"
                     v-model="form.task"
                     required/>
                 </vue-grid-item>
@@ -40,7 +40,7 @@
                   <vue-input
                     name="brief"
                     id="brief"
-                    placeholder="Job Description"
+                    :placeholder="$t('App.createJob.JobDescriptionInForm')"
                     v-model="form.brief"
                     required/>
                 </vue-grid-item>
@@ -57,7 +57,7 @@
                   <vue-input
                     name="deliverable"
                     id="deliverable"
-                    placeholder="Requirement for Job to be Complete"
+                    :placeholder="$t('App.createJob.requirementInForm')"
                     v-model="requirement"
                     required/>
                   <button accent @click="addRequirement">{{ $t('App.createJob.requirementButton' /* Add Requirement */) }}
@@ -97,7 +97,7 @@
                     name="termOfEmployment"
                     id="termOfEmployment"
                     type="number"
-                    placeholder="Number of Months of Employment"
+                    :placeholder="$t('App.createJob.nrMonthsInForm')"
                     v-model="form.termOfEmployment"
                     required/>
                   <div>{{ $t('App.createJob.termOfEmploymentExplanation' /* Months of work is also referenced as
@@ -126,7 +126,7 @@
                     name="salary"
                     id="salary"
                     type="number"
-                    placeholder="Total Funding (Salary) for Job in USD"
+                    :placeholder="$t('App.createJob.totalFoundingInForm')"
                     v-model="form.salary"
                     required/>
                   <div>{{ $t('App.createJob.salaryPayoutDisclaimer' /* Remember: (1) The salary you list above will be
@@ -145,7 +145,8 @@
                     id="domain"
                     placeholder="Job Category"
                     v-model="form.domain"
-                    :options="domainOptions"
+                    :options="$t('domainOptions')"
+                    :key="locale"
                     required/>
                 </vue-grid-item>
                 <vue-grid-item>
@@ -154,7 +155,8 @@
                     id="skill"
                     placeholder="Top Desired Skill"
                     v-model="form.skill"
-                    :options="skillOptions"
+                    :options="$t('skillOptions')"
+                    :key="locale"
                     required/>
                 </vue-grid-item>
               </vue-grid-row>
@@ -165,7 +167,8 @@
                     name="country"
                     id="country"
                     v-model="form.country"
-                    :options="countryOptions"
+                    :options="$t('countryOptions')"
+                    :key="locale"
                     required/>
                 </vue-grid-item>
               </vue-grid-row>
@@ -175,7 +178,7 @@
                   <vue-input
                     name="cityOfWork"
                     id="cityOfWork"
-                    placeholder="City where work is to be performed"
+                    :placeholder="$t('App.job.cityOfWork')"
                     v-model="form.cityOfWork"
                     required/>
                 </vue-grid-item>
@@ -261,24 +264,6 @@
           isDatePostedDisabled: true,
           acceptTerms: false
         },
-        countryOptions: [
-          {label: 'Choose a Country', value: null},
-          {label: 'Haiti', value: 'haiti'},
-          {label: 'USA', value: 'us'}
-        ],
-        skillOptions: [
-          {label: 'Choose Top Desired Skill', value: null},
-          {label: 'Administrative', value: 'administrative'},
-          {label: 'Engineering', value: 'engineering'},
-          {label: 'Labor', value: 'labor'},
-          {label: 'Teaching', value: 'teaching'}
-        ],
-        domainOptions: [
-          {label: 'Choose a Job Category', value: null},
-          {label: 'Community', value: 'community'},
-          {label: 'Education', value: 'education'},
-          {label: 'Environment', value: 'environment'}
-        ],
         isLoading: false,
         requirement: '',
         status: {}

--- a/src/components/profile.vue
+++ b/src/components/profile.vue
@@ -38,11 +38,11 @@
 
                   <vue-grid-row>
                     <vue-grid-item>
-                      <vue-input type="text" name="country" id="country" placeholder="Country Code" readonly
+                      <vue-input type="text" name="country" id="country" :placeholder="$t('App.profile.countryCodeTitle')" readonly
                                  v-model="form.country"/>
                     </vue-grid-item>
                     <vue-grid-item>
-                      <vue-input type="text" name="number" id="number" placeholder="Number" required
+                      <vue-input type="text" name="number" id="number" :placeholder="$t('App.profile.numberTitle')" required
                                  v-model="form.number"/>
                     </vue-grid-item>
                   </vue-grid-row>
@@ -87,7 +87,7 @@
       <vue-grid-row>
         <vue-grid-item>
           <vue-accordion multiple>
-            <vue-accordion-item title="Incomplete Jobs">
+            <vue-accordion-item :title="$t('App.profile.incompleteJobsTitle')">
               {{ $t('App.profile.incompleteJobs' /* List of all jobs that are still open. */) }}
               <div
                 v-for="(item, index) in incompleteJobs"
@@ -96,7 +96,7 @@
               </div>
             </vue-accordion-item>
 
-            <vue-accordion-item title="Completed Jobs">
+            <vue-accordion-item :title="$t('App.profile.completedJobsTitle')">
               {{ $t('App.profile.completedJobs' /* List of all jobs that have all been completed and closed. */) }}
               <div
                 v-for="(item, index) in completedJobs"
@@ -105,7 +105,7 @@
               </div>
             </vue-accordion-item>
 
-            <vue-accordion-item title="Canceled Jobs">
+            <vue-accordion-item :title="$t('App.profile.canceledJobsTitle')">
               {{ $t('App.profile.canceledJobs' /* List of all jobs that have all been canceled. */) }}
               <div
                 v-for="(item, index) in canceledJobs"
@@ -114,7 +114,7 @@
               </div>
             </vue-accordion-item>
 
-            <vue-accordion-item title="Jobs You're Managing">
+            <vue-accordion-item :title="$t('App.profile.managingJobsTitle')">
               {{ $t('App.profile.managingJobs' /* List of all jobs you are managing. */) }}
               <div
                 v-for="(item, index) in managingJobs"
@@ -123,7 +123,7 @@
               </div>
             </vue-accordion-item>
 
-            <vue-accordion-item title="Jobs You're Evaluating">
+            <vue-accordion-item :title="$t('App.profile.evaluatingJobsTitle')">
               {{ $t('App.profile.evaluatingJobs' /* List of all jobs you are listed as the Evaluator. */) }}
               <div
                 v-for="(item, index) in evaluatingJobs"
@@ -135,7 +135,7 @@
               </template>
             </vue-accordion-item>
 
-            <vue-accordion-item title="Jobs You've Sponsored">
+            <vue-accordion-item :title="$t('App.profile.sponsoringJobsTitle')">
               {{ $t('App.profile.sponsoringJobs' /* List of all jobs you've sponsored. */) }}
               <div
                 v-for="(item, index) in sponsored"


### PR DESCRIPTION
##### Description
<!-- A description on what this PR aims to solve -->
- This PR fix the issues regard text translate using i18n.
- I have not added new parameters in `i18n/fr.json`, only in another two files. I can add in it too without problems.
- I had to mode `domainOptions`, `skillOptions` and `countryOptions` arrays from `data()` inside `js` code to external i18n json, because it does not translate text if the arrays have been created during init phase returned by `data()`.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [X] Every title in an accordion on the profile can switch to another language using i18n.
- [X] All placeholder text in the createJob page can switch to another language using i18n.
- [X] All dropdowns in the createJob page can switch to another language using i18n.
- [X] i18n is installed globally, so all the above should work in any page in the app.
- [X] Changes don't break existing behavior


##### Testing
<!-- Why should the PR reviewer trust that this change doesn't break anything? How have you tested this change? -->

##### Refers/Fixes
<!--
  Link to an issue if applicable. For example:
  If your PR fixes an issue -- Fixes: #102
  If your PR refers an issue -- Refs: #101
-->
Fixes: #14 
